### PR TITLE
Fix iterating over keys when changelog topic is set.

### DIFF
--- a/faust/stores/rocksdb.py
+++ b/faust/stores/rocksdb.py
@@ -388,7 +388,7 @@ class Store(base.SerializedStore):
 
     def _dbs_for_actives(self) -> Iterator[DB]:
         actives = self.app.assignor.assigned_actives()
-        topic = self.table._changelog_topic_name()
+        topic = self.table.changelog_topic_name
         for partition, db in self._dbs.items():
             tp = TP(topic=topic, partition=partition)
             if tp in actives:


### PR DESCRIPTION
Changes the RocksDB store to check the assigned topic name for a changelog, rather than the auto-generated one. If the changelog uses a manually-created topic, using the auto-generated name causes keys(), values(), items() on the Table object that this store backs to return no data, since the changelog names never match.

Resolves #654
original author: https://github.com/robinhood/faust/pull/655